### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,8 @@ export default App;
 
 To view and interact with the `CSVHandler` component in a Storybook environment, run the command:
 
-   ```bash
-   pnpm run storybook
+```bash
+pnpm run storybook
+```
+
+This will start Storybook locally so you can browse and test the component.


### PR DESCRIPTION
## Summary
- close the Storybook bash code block in the README
- add an explanation of how to run Storybook

## Testing
- `pnpm run lint` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859230cda288330a6d1c86623b2d5e1